### PR TITLE
emacs 24 hangs when using pysmell/ropemacs

### DIFF
--- a/pymacs.el.in
+++ b/pymacs.el.in
@@ -523,8 +523,10 @@ The timer is used only if `post-gc-hook' is not available.")
                           python))
                       "-c" (concat "import sys;"
                                    " from Pymacs.pymacs import main;"
-                                   " main(*sys.argv[1:])")
-                      (mapcar 'expand-file-name pymacs-load-path))))
+				   " main(*sys.argv[1:])")
+		      (append
+		       (and (>= emacs-major-version 24) '("-f"))
+		       (mapcar 'expand-file-name pymacs-load-path)))))
           (pymacs-kill-without-query process)
           ;; Receive the synchronising reply.
           (while (progn


### PR DESCRIPTION
somehow the python process doesn't read a full command when not clearing the ICANON flag.
This happens for commands larger than 4096 bytes. my commit fixes the issue for me.
