### PR TITLE
specifying encoding="utf-8" when opening files

### DIFF
--- a/pppp
+++ b/pppp
@@ -238,7 +238,7 @@ class Main:
                 if self.verbose:
                     sys.stderr.write("writing %s\n" % output)
                 self.transform_file(
-                        input, open(input), open(output, 'w').write)
+                        input, open(input, encoding='utf-8'), open(output, 'w', encoding='utf-8').write)
                 if output.endswith('.py'):
                     pyc_file = output[:-2] + '.pyc'
                     if os.path.exists(pyc_file):

--- a/ppppconfig.py
+++ b/ppppconfig.py
@@ -7,7 +7,7 @@
 # VERSION is the name of the Pymacs version, as declared within setup.py.
 
 def get_version():
-    for line in open('setup.cfg'):
+    for line in open('setup.cfg', encoding='utf-8'):
         if '=' in line:
             key, value = line.split('=', 1)
             if key.strip() == 'version':


### PR DESCRIPTION
this allows Pymacs.py to be built when LANG=C
