### PR TITLE
fix install of Pymacs on Python 2.7 (issue #28)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ requires_python = >=2.2
 license = GPLv2
 
 [files]
+modules = Pymacs
 extra_files = 
     COPYING
     Makefile


### PR DESCRIPTION
I observe the same behaviour reported by a few other users:
- `make install` runs the `pppp` preprocessor but doesn't put anything except the egg-info file into my `site-packages`
- `python setup.py install` does exactly the same thing

To install Pymacs, I have to copy `Pymacs.py` manually into my `site-packages`

If I list Pymacs as a module in the `setup.cfg` file, then the file is installed correctly.
