### PR TITLE
Making Makefile variables accessible from from make task.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ install: prepare
 	$(PYSETUP) install
 
 prepare:
-	$(PPPP) Pymacs.py.in pppp.rst.in pymacs.el.in pymacs.rst.in contrib tests
+	EMACS="$(EMACS)" PYTHON="$(PYTHON)" \
+	  $(PPPP) Pymacs.py.in pppp.rst.in pymacs.el.in pymacs.rst.in contrib tests
 
 clean: clean-debug
 	rm -rf build* contrib/rebox/build
@@ -34,7 +35,8 @@ clean-debug:
 	rm -f tests/debug-protocol tests/debug-signals
 
 pppp.pdf: pppp.rst.in
-	$(PPPP) pppp.rst.in
+	EMACS="$(EMACS)" PYTHON="$(PYTHON)" \
+	  $(PPPP) pppp.rst.in
 	rm -rf tmp-pdf
 	mkdir tmp-pdf
 	$(RST2LATEX) --use-latex-toc --input-encoding=UTF-8 \
@@ -45,7 +47,8 @@ pppp.pdf: pppp.rst.in
 	rm -rf tmp-pdf
 
 pymacs.pdf: pymacs.rst.in
-	$(PPPP) pymacs.rst.in
+	EMACS="$(EMACS)" PYTHON="$(PYTHON)" \
+	  $(PPPP) pymacs.rst.in
 	rm -rf tmp-pdf
 	mkdir tmp-pdf
 	$(RST2LATEX) --use-latex-toc --input-encoding=UTF-8 \

--- a/pymacs.el.in
+++ b/pymacs.el.in
@@ -118,7 +118,7 @@ When this variable is nil, strings are transmitted as copies, and the
 Python side thus has no way for modifying the original Lisp strings.
 This variable is ignored whenever `forget-mutability' is set.")
 
-(defvar pymacs-timeout-at-start 30
+(defvar pymacs-timeout-at-start 60
   "Maximum reasonable time, in seconds, for starting the Pymacs helper.
 A machine should be pretty loaded before one needs to increment this.")
 


### PR DESCRIPTION
When I tried to install Pymacs on my Arch linux, i fall into problems, since Arch linux has default python as a python3, and when i set PYTHON variable in Makefile it wasn't recognized in the scirpts.
So the commit is about:

Made visable environment variables: PYTHON, EMACS, for make task based
on values in Makefile header.
This is usefull take default values based on the ones in
Makefile. Previously if we modyfied Makefile PYTHON value the check task
perform check agains PYTHON vale, but prepare didn't.
