### PR TITLE
Fix incorrect access of context for -Dvar definitions.

### DIFF
--- a/pppp
+++ b/pppp
@@ -83,7 +83,7 @@ class Main:
                     name, value = value.split('=', 1)
                     self.context[name] = eval(value, {})
                 else:
-                    self.context[name] = True
+                    self.context[value] = True
             elif option == '-c':
                 self.clean = True
             elif option == '-f':


### PR DESCRIPTION
When a variable is defined in the command line using '-Dvar', an
exception occurs. This is because the code accesses the context
dictionary using the 'name' variable instead of the 'value' variable.
