### PR TITLE
Fix Python 2 compatibility for `sys.stdout`.

### DIFF
--- a/Pymacs.py.in
+++ b/Pymacs.py.in
@@ -379,9 +379,9 @@ class Protocol:
                 handle = open(run.debug_file, 'a')
                 handle.write(prefix + text)
                 handle.close()
-            sys.stdout.buffer.write(prefix.encode('ASCII'))
-            sys.stdout.buffer.write(data)
-            sys.stdout.buffer.flush()
+            sys.stdout.write(prefix.encode('ASCII'))
+            sys.stdout.write(data)
+            sys.stdout.flush()
 
     else:
 


### PR DESCRIPTION
There's no `buffer`, so this part fails to load.  Tested with Python 2.7
(where it previously failed for me) and Python 3.2.
